### PR TITLE
feature/interlok-3232 SMTP CC/BCC resolvable expressions

### DIFF
--- a/src/main/java/com/adaptris/core/mail/DefaultSmtpProducer.java
+++ b/src/main/java/com/adaptris/core/mail/DefaultSmtpProducer.java
@@ -30,6 +30,7 @@ import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.mail.SmtpClient;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Email implementation of the AdaptrisMessageProducer interface.
@@ -61,9 +62,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * the <code>javax.mail.Session</code> instance. You need to refer to the javamail documentation to see a list of the available
  * properties and meanings.
  * </p>
- * 
+ *
  * @config default-smtp-producer
- * 
+ *
  * @see MailProducer
  * @see CoreConstants#EMAIL_SUBJECT
  * @see CoreConstants#EMAIL_ATTACH_FILENAME
@@ -73,7 +74,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("default-smtp-producer")
 @AdapterComponent
-@ComponentProfile(summary = "Send an email", tag = "producer,email", recommended = {NullConnection.class})
+@ComponentProfile(summary = "Send an email", tag = "producer,email,smtp,mail", recommended = {NullConnection.class})
 @DisplayOrder(order = {"smtpUrl", "username", "password", "subject", "from", "ccList", "bccList"})
 public class DefaultSmtpProducer extends MailProducer {
 
@@ -99,8 +100,6 @@ public class DefaultSmtpProducer extends MailProducer {
 
   /**
    * @see Object#Object()
-   *
-   *
    */
   public DefaultSmtpProducer() {
     super();
@@ -117,7 +116,10 @@ public class DefaultSmtpProducer extends MailProducer {
       SmtpClient smtp = getClient(msg);
       smtp.setEncoding(msg.resolve(contentEncoding()));
       byte[] encodedPayload = encode(msg);
-      smtp.addTo(destination.getDestination(msg));
+      String toAddresses = destination != null ? destination.getDestination(msg) : null;
+      if (!StringUtils.isEmpty(toAddresses)) {
+        smtp.addTo(toAddresses);
+      }
       String ctype = getContentType(msg);
 
       if (isAttachment()) {
@@ -197,7 +199,6 @@ public class DefaultSmtpProducer extends MailProducer {
   public void setContentEncoding(String s) {
     contentEncoding = s;
   }
-
 
   /**
    * Get the encoding of the email.

--- a/src/main/java/com/adaptris/core/mail/DefaultSmtpProducer.java
+++ b/src/main/java/com/adaptris/core/mail/DefaultSmtpProducer.java
@@ -123,8 +123,7 @@ public class DefaultSmtpProducer extends MailProducer {
       String ctype = getContentType(msg);
 
       if (isAttachment()) {
-        String template = msg
-            .getMetadataValue(EmailConstants.EMAIL_TEMPLATE_BODY);
+        String template = msg.getMetadataValue(EmailConstants.EMAIL_TEMPLATE_BODY);
         if (template != null) {
           if (msg.getContentEncoding() != null) {
             smtp.setMessage(template.getBytes(msg.getContentEncoding()), ctype);

--- a/src/main/java/com/adaptris/core/mail/EmailConstants.java
+++ b/src/main/java/com/adaptris/core/mail/EmailConstants.java
@@ -1,8 +1,11 @@
 package com.adaptris.core.mail;
 
+import com.adaptris.annotation.Removal;
+
 /**
  * @deprecated since 3.10.0, slated for removal in 3.11.0.
  */
+@Removal(message = "Use message resolver to reference metadata keys", version = "3.11.0")
 @Deprecated
 public class EmailConstants {
 
@@ -11,6 +14,7 @@ public class EmailConstants {
    * 
    * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailsubject}", version = "3.11.0")
   @Deprecated
   public static final String EMAIL_SUBJECT = "emailsubject";
 
@@ -19,6 +23,7 @@ public class EmailConstants {
    *
    * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailattachmentfilename}", version = "3.11.0")
   @Deprecated
   public static final String EMAIL_ATTACH_FILENAME = "emailattachmentfilename";
 
@@ -27,14 +32,16 @@ public class EmailConstants {
    *
    * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailattachmentcontenttype}", version = "3.11.0")
   @Deprecated
-  public static final String EMAIL_ATTACH_CONTENT_TYPE = "emailattachment" + "contenttype";
+  public static final String EMAIL_ATTACH_CONTENT_TYPE = "emailattachmentcontenttype";
 
   /**
    * Metadata key that specifies the total number of attachments.
    *
    * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailtotalattachments}", version = "3.11.0")
   @Deprecated
   public static final String EMAIL_TOTAL_ATTACHMENTS = "emailtotalattachments";
 
@@ -43,6 +50,7 @@ public class EmailConstants {
    *
    * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailcc}", version = "3.11.0")
   @Deprecated
   public static final String EMAIL_CC_LIST = "emailcc";
 
@@ -51,6 +59,7 @@ public class EmailConstants {
    *
    * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailmessageid}", version = "3.11.0")
   @Deprecated
   public static final String EMAIL_MESSAGE_ID = "emailmessageid";
 
@@ -60,6 +69,7 @@ public class EmailConstants {
    *
    * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailtemplatebody}", version = "3.11.0")
   @Deprecated
   public static final String EMAIL_TEMPLATE_BODY = "emailtemplatebody";
 }

--- a/src/main/java/com/adaptris/core/mail/EmailConstants.java
+++ b/src/main/java/com/adaptris/core/mail/EmailConstants.java
@@ -1,48 +1,65 @@
 package com.adaptris.core.mail;
 
+/**
+ * @deprecated since 3.10.0, slated for removal in 3.11.0.
+ */
+@Deprecated
 public class EmailConstants {
 
   /**
    * Metadata key specifying the email subject.
    * 
+   * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Deprecated
   public static final String EMAIL_SUBJECT = "emailsubject";
 
   /**
    * Metadata key that specifies the name of the attachment.
-   * 
+   *
+   * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Deprecated
   public static final String EMAIL_ATTACH_FILENAME = "emailattachmentfilename";
 
   /**
    * Metadata key that specifies the content-type of the attachment.
-   * 
+   *
+   * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Deprecated
   public static final String EMAIL_ATTACH_CONTENT_TYPE = "emailattachment" + "contenttype";
 
   /**
    * Metadata key that specifies the total number of attachments.
-   * 
+   *
+   * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Deprecated
   public static final String EMAIL_TOTAL_ATTACHMENTS = "emailtotalattachments";
 
   /**
    * Metadata key that specifies the cc list for sending.
-   * 
+   *
+   * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Deprecated
   public static final String EMAIL_CC_LIST = "emailcc";
 
   /**
    * Metadata key specifying the email message container from whence a payload may have spawned.
-   * 
+   *
+   * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Deprecated
   public static final String EMAIL_MESSAGE_ID = "emailmessageid";
 
   /**
    * Metadata key specifying the email body. This is only used if the <code>SmtpProducer</code> is configured to send the document
    * as an attachment.
-   * 
+   *
+   * @deprecated since 3.10.0, slated for removal in 3.11.0.
    */
+  @Deprecated
   public static final String EMAIL_TEMPLATE_BODY = "emailtemplatebody";
-
 }

--- a/src/main/java/com/adaptris/core/mail/MailProducer.java
+++ b/src/main/java/com/adaptris/core/mail/MailProducer.java
@@ -195,7 +195,7 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
   /**
    * @deprecated since 3.10.0, slated for removal in 3.11.0, use message resolver instead.
    */
-  @Deprecated(since = "3.10.0", forRemoval = true)
+  @Deprecated
   private String getSubject(AdaptrisMessage msg) {
     return msg.containsKey(EmailConstants.EMAIL_SUBJECT) ? msg.getMetadataValue(EmailConstants.EMAIL_SUBJECT) : msg.resolve(getSubject());
   }
@@ -203,7 +203,7 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
   /**
    * @deprecated since 3.10.0, slated for removal in 3.11.0, use message resolver instead.
    */
-  @Deprecated(since = "3.10.0", forRemoval = true)
+  @Deprecated
   private String getCC(AdaptrisMessage msg) {
     return msg.containsKey(EmailConstants.EMAIL_CC_LIST) ? msg.getMetadataValue(EmailConstants.EMAIL_CC_LIST) : msg.resolve(getCcList());
   }

--- a/src/main/java/com/adaptris/core/mail/MailProducer.java
+++ b/src/main/java/com/adaptris/core/mail/MailProducer.java
@@ -73,6 +73,7 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
 
   @NotBlank
   private String smtpUrl = null;
+  @InputFieldHint(expression = true)
   private String subject = null;
   @AdvancedConfig
   @InputFieldHint(expression = true)
@@ -191,10 +192,18 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
     return subject;
   }
 
+  /**
+   * @deprecated since 3.10.0, slated for removal in 3.11.0, use message resolver instead.
+   */
+  @Deprecated(since = "3.10.0", forRemoval = true)
   private String getSubject(AdaptrisMessage msg) {
-    return msg.containsKey(EmailConstants.EMAIL_SUBJECT) ? msg.getMetadataValue(EmailConstants.EMAIL_SUBJECT) : getSubject();
+    return msg.containsKey(EmailConstants.EMAIL_SUBJECT) ? msg.getMetadataValue(EmailConstants.EMAIL_SUBJECT) : msg.resolve(getSubject());
   }
 
+  /**
+   * @deprecated since 3.10.0, slated for removal in 3.11.0, use message resolver instead.
+   */
+  @Deprecated(since = "3.10.0", forRemoval = true)
   private String getCC(AdaptrisMessage msg) {
     return msg.containsKey(EmailConstants.EMAIL_CC_LIST) ? msg.getMetadataValue(EmailConstants.EMAIL_CC_LIST) : msg.resolve(getCcList());
   }

--- a/src/test/java/com/adaptris/core/mail/DefaultMailProducerTest.java
+++ b/src/test/java/com/adaptris/core/mail/DefaultMailProducerTest.java
@@ -139,6 +139,30 @@ public class DefaultMailProducerTest extends MailProducerExample {
   }
 
   @Test
+  public void testProduceMetadataSubjectCC() throws Exception {
+    Assume.assumeTrue(testsEnabled());
+    GreenMail gm = JunitMailHelper.startServer();
+    try {
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JunitMailHelper.DEFAULT_PAYLOAD);
+      msg.addMetadata(EmailConstants.EMAIL_CC_LIST, "CarbonCopy@CarbonCopy.com");   // these will force the use of (the
+      msg.addMetadata(EmailConstants.EMAIL_SUBJECT, "Some very important subject"); // now deprecated) metadata keys
+      StandaloneProducer producer = createProducerForTests(gm);
+      ServiceCase.execute(producer, msg);
+      gm.waitForIncomingEmail(1);
+      MimeMessage[] msgs = gm.getReceivedMessages();
+      assertEquals(2, msgs.length);
+      for (MimeMessage mime : msgs) {
+        JunitMailHelper.assertFrom(mime, DEFAULT_SENDER);
+        JunitMailHelper.assertTo(mime, DEFAULT_RECEIVER);
+        JunitMailHelper.assertCC(mime, "CarbonCopy@CarbonCopy.com");
+      }
+    }
+    finally {
+      JunitMailHelper.stopServer(gm);
+    }
+  }
+
+  @Test
   public void testProduceNoAddresseeButResolveCC() throws Exception {
     Assume.assumeTrue(testsEnabled());
     GreenMail gm = JunitMailHelper.startServer();

--- a/src/test/java/com/adaptris/mail/JunitMailHelper.java
+++ b/src/test/java/com/adaptris/mail/JunitMailHelper.java
@@ -17,6 +17,7 @@
 package com.adaptris.mail;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
@@ -113,6 +114,10 @@ public class JunitMailHelper {
     if (!find(addresses, email)) {
       fail("Could not find " + email + " in TO list");
     }
+  }
+
+  public static void assertRecipientNull(MimeMessage m) throws Exception {
+    assertNull(m.getRecipients(Message.RecipientType.TO));
   }
 
   public static void assertCC(MimeMessage m, String email) throws Exception {


### PR DESCRIPTION
## Motivation

Users would like enhanced CC and BCC fields to allow resolvable %message{...} expressions, as well as an empty TO field.

## Modification

* Only set the TO field if the destination is set (not null).
* Add UI hints and calls to resolve for CC and BCC
* Add deprecation warning for the hardcoded metadata fields (resolvable expressions are more useful)

## Result

They now do not have to set a TO address, and can use %message{...} expressions to give greater control over CC and BCC fields.

## Testing

Unit tests all run and pass as before. But if you're feeling like really testing, you'll need an SMTP server you can connect and send mail through. Something like the following should do it (just remember to set the metadata values).

```xml
<producer class="default-smtp-producer">
    <unique-id>smtp-producer</unique-id>
    <smtp-url>smtps://mail.example.com</smtp-url>
    <subject>Email from Interlok</subject>
    <cc-list>%message{user-1},%message{user-2}</cc-list>
    <from>interlok@ashley.anderson.io</from>
    <bcc-list>%message{user-3},%message{user-4}</bcc-list>
    <session-properties/>
    <metadata-filter class="remove-all-metadata-filter"/>
    <password>some-password</password>
    <username>user</username>
</producer>
```