### PR TITLE
INTERLOK-3831 Remove deprecated items

### DIFF
--- a/src/main/java/com/adaptris/core/mail/EmailConstants.java
+++ b/src/main/java/com/adaptris/core/mail/EmailConstants.java
@@ -1,33 +1,41 @@
 package com.adaptris.core.mail;
 
 import com.adaptris.annotation.Removal;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailConstants {
 
   /**
    * Metadata key specifying the email subject.
-   * 
-   * @deprecated since 3.10.0, slated for removal in 3.11.0.
+   *
+   * @deprecated since 3.10.0, slated for removal in 4.0.
    */
-  @Removal(message = "Use message resolver to reference metadata keys: %message{emailsubject}", version = "3.11.0")
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailsubject}",
+      version = "4.0")
   @Deprecated
   public static final String EMAIL_SUBJECT = "emailsubject";
 
   /**
    * Metadata key that specifies the name of the attachment.
    *
-   * @deprecated since 3.10.0, slated for removal in 3.11.0.
+   * @deprecated since 3.10.0, slated for removal in 4.0.
    */
-  @Removal(message = "Use message resolver to reference metadata keys: %message{emailattachmentfilename}", version = "3.11.0")
+  @Removal(
+      message = "Use message resolver to reference metadata keys: %message{emailattachmentfilename}",
+      version = "4.0")
   @Deprecated
   public static final String EMAIL_ATTACH_FILENAME = "emailattachmentfilename";
 
   /**
    * Metadata key that specifies the content-type of the attachment.
    *
-   * @deprecated since 3.10.0, slated for removal in 3.11.0.
+   * @deprecated since 3.10.0, slated for removal in 4.0.
    */
-  @Removal(message = "Use message resolver to reference metadata keys: %message{emailattachmentcontenttype}", version = "3.11.0")
+  @Removal(
+      message = "Use message resolver to reference metadata keys: %message{emailattachmentcontenttype}",
+      version = "4.0")
   @Deprecated
   public static final String EMAIL_ATTACH_CONTENT_TYPE = "emailattachmentcontenttype";
 
@@ -40,9 +48,10 @@ public class EmailConstants {
   /**
    * Metadata key that specifies the cc list for sending.
    *
-   * @deprecated since 3.10.0, slated for removal in 3.11.0.
+   * @deprecated since 3.10.0, slated for removal in 4.0
    */
-  @Removal(message = "Use message resolver to reference metadata keys: %message{emailcc}", version = "3.11.0")
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailcc}",
+      version = "4.0")
   @Deprecated
   public static final String EMAIL_CC_LIST = "emailcc";
 
@@ -53,12 +62,16 @@ public class EmailConstants {
   public static final String EMAIL_MESSAGE_ID = "emailmessageid";
 
   /**
-   * Metadata key specifying the email body. This is only used if the <code>SmtpProducer</code> is configured to send the document
-   * as an attachment.
+   * Metadata key specifying the email body. This is only used if the <code>SmtpProducer</code> is
+   * configured to send the document as an attachment.
    *
-   * @deprecated since 3.10.0, slated for removal in 3.11.0.
+   * @deprecated since 3.10.0, slated for removal in 4.0
    */
-  @Removal(message = "Use message resolver to reference metadata keys: %message{emailtemplatebody}", version = "3.11.0")
+  @Removal(message = "Use message resolver to reference metadata keys: %message{emailtemplatebody}",
+      version = "4.0")
   @Deprecated
   public static final String EMAIL_TEMPLATE_BODY = "emailtemplatebody";
+
+  public static final String TEXT_PLAIN = "text/plain";
+
 }

--- a/src/main/java/com/adaptris/core/mail/MailConsumerImp.java
+++ b/src/main/java/com/adaptris/core/mail/MailConsumerImp.java
@@ -149,7 +149,7 @@ public abstract class MailConsumerImp extends AdaptrisPollingConsumer{
 
   @Override
   protected void prepareConsumer() throws CoreException {
-    DestinationHelper.logConsumeDestinationWarning(destinationWarningLogged,
+    DestinationHelper.logWarningIfNotNull(destinationWarningLogged,
         () -> destinationWarningLogged = true, getDestination(),
         "{} uses destination, use path + methods instead", LoggingHelper.friendlyName(this));
     DestinationHelper.mustHaveEither(getMailboxUrl(), getDestination());

--- a/src/main/java/com/adaptris/core/mail/MailHelper.java
+++ b/src/main/java/com/adaptris/core/mail/MailHelper.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,13 @@
 package com.adaptris.core.mail;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import javax.mail.URLName;
-
 import com.adaptris.security.exc.PasswordException;
 import com.adaptris.security.password.Password;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class MailHelper {
 
   static final URLName createURLName(String urlString, String username, String password) throws PasswordException {

--- a/src/main/java/com/adaptris/core/mail/MailProducer.java
+++ b/src/main/java/com/adaptris/core/mail/MailProducer.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.core.mail;
 
-import java.util.Iterator;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -37,7 +36,6 @@ import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.RemoveAllMetadataFilter;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DestinationHelper;
-import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.mail.MailException;
@@ -46,6 +44,7 @@ import com.adaptris.security.exc.PasswordException;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 /**
@@ -54,12 +53,6 @@ import lombok.Setter;
  * Because email is implicitly asynchronous, Request-Reply is invalid, and as such if the request method is used, an
  * <code>UnsupportedOperationException</code> is thrown.
  * </p>
- * <p>
- * The following metadata elements will change behaviour.
- * <ul>
- * <li>emailsubject - Override the configured subject with the value stored against this key.
- * <li>emailcc - If this is set, this this comma separated list will override any configured CC list.</li>
- * </ul>
  * <p>
  * It is possible to control the underlying behaviour of this producer through the use of various properties that will be passed to
  * the <code>javax.mail.Session</code> instance. You need to refer to the javamail documentation to see a list of the available
@@ -78,29 +71,99 @@ import lombok.Setter;
  */
 public abstract class MailProducer extends ProduceOnlyProducerImp {
 
+  /**
+   * The SMTP Server.
+   *
+   */
   @NotBlank
+  @Getter
+  @Setter
+  @NonNull
   private String smtpUrl = null;
+  /**
+   * The subject for the email.
+   *
+   */
   @InputFieldHint(expression = true)
+  @Getter
+  @Setter
   private String subject = null;
+  /**
+   * A comma separated list of email addresses to 'cc'
+   *
+   */
+  @Getter
+  @Setter
   @AdvancedConfig
   @InputFieldHint(expression = true)
   private String ccList = null;
+  /**
+   * The 'From' Address
+   *
+   */
+  @Getter
+  @Setter
   private String from = null;
+  /**
+   * A comma separated list of email addresses to 'bcc'
+   *
+   */
+  @Getter
+  @Setter
   @AdvancedConfig
   @InputFieldHint(expression = true)
   private String bccList = null;
+  /**
+   * Any additional behaviour that should be applied to the underlying {@code javax.mail.Session}.
+   * <p>
+   * You probably need to consult the javamail documentation to find the exhaustive list of
+   * properties.
+   * </p>
+   */
+  @Getter
+  @Setter
   @NotNull
   @Valid
   @AutoPopulated
   @AdvancedConfig
   private KeyValuePairSet sessionProperties;
+
+  /**
+   * Specify the {@link com.adaptris.core.AdaptrisMessage} metadata keys that will be sent as
+   * headers for the mail message.
+   * <p>
+   * Any metadata that is returned by this filter will be sent as headers. It defaults to
+   * {@link RemoveAllMetadataFilter} if not specified.
+   * </p>
+   */
+  @Getter
+  @Setter
   @NotNull
   @AutoPopulated
   @Valid
   @AdvancedConfig
+  @NonNull
   private MetadataFilter metadataFilter;
+  /**
+   * The password associated with the SMTP Server
+   * <p>
+   * If you specify the username and password in the URL for the SMTP server then does not lend
+   * itself to being encrypted. Specify the password here if you wish to use
+   * {@link com.adaptris.security.password.Password#decode(String)} to decode the password.
+   * </p>
+   */
+  @Getter
+  @Setter
   @InputFieldHint(style = "PASSWORD", external = true)
   private String password;
+  /**
+   * Set an optional username for the SMTP Server.
+   * <p>
+   * The username which will be overriden if a username is present in the URL
+   * </p>
+   */
+  @Getter
+  @Setter
   private String username;
 
   /**
@@ -129,82 +192,15 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
     setMetadataFilter(new RemoveAllMetadataFilter());
   }
 
-  /** @see com.adaptris.core.AdaptrisComponent#init() */
-  @Override
-  public void init() throws CoreException {
-    try {
-      Args.notNull(getSmtpUrl(), "smtpUrl");
-      if (getSubject() == null) {
-        log.warn("No Subject configured, expecting metadata to override subject");
-      }
-    }
-    catch (Exception e) {
-      throw ExceptionHelper.wrapCoreException(e);
-    }
-  }
-
   @Override
   public void prepare() throws CoreException {
+    Args.notNull(getSmtpUrl(), "smtpUrl");
     DestinationHelper.logWarningIfNotNull(destWarning, () -> destWarning = true, getDestination(),
         "{} uses destination, use 'to' instead", LoggingHelper.friendlyName(this));
     // To is optional if you want to just use bcc !.
     // DestinationHelper.mustHaveEither(getPath(), getDestination());
 
     registerEncoderMessageFactory();
-  }
-
-  /**
-   * Set the SMTP url.
-   *
-   * @param url the url e.g. smtp://localhost:25/
-   */
-  public void setSmtpUrl(String url) {
-    smtpUrl = url;
-  }
-
-  /**
-   * Get the SMTP url.
-   *
-   * @return the url.
-   */
-  public String getSmtpUrl() {
-    return smtpUrl;
-  }
-
-  /**
-   * Set the list of CCs.
-   *
-   * @param ccList a comma separated list of CC addresses
-   */
-  public void setCcList(String ccList) {
-    this.ccList = ccList;
-  }
-
-  /**
-   * Get the list of CC's.
-   *
-   * @return the list of CC's
-   */
-  public String getCcList() {
-    return ccList;
-  }
-
-  /**
-   * Set the subject for the email.
-   *
-   * @param s the subject.
-   */
-  public void setSubject(String s) {
-    subject = s;
-  }
-
-  /**
-   * Get the subject of the email.
-   *
-   * @return the subject.
-   */
-  public String getSubject() {
-    return subject;
   }
 
   /**
@@ -223,12 +219,20 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
     return msg.containsKey(EmailConstants.EMAIL_CC_LIST) ? msg.getMetadataValue(EmailConstants.EMAIL_CC_LIST) : msg.resolve(getCcList());
   }
 
+  protected SmtpClient getClient(AdaptrisMessage msg, String toAddresses)
+      throws MailException, PasswordException {
+    SmtpClient smtp = getClient(msg);
+    if (!StringUtils.isEmpty(toAddresses)) {
+      smtp.addTo(toAddresses);
+    }
+    return smtp;
+  }
+
+
   protected SmtpClient getClient(AdaptrisMessage msg) throws MailException, PasswordException {
     SmtpClient smtp = new SmtpClient(
         MailHelper.createURLName(getSmtpUrl(), getUsername(), ExternalResolver.resolve(getPassword())));
-    Iterator i = sessionProperties.getKeyValuePairs().iterator();
-    while (i.hasNext()) {
-      KeyValuePair kp = (KeyValuePair) i.next();
+    for (KeyValuePair kp : getSessionProperties()) {
       smtp.addSessionProperty(kp.getKey(), kp.getValue());
     }
     smtp.startSession();
@@ -244,112 +248,11 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
     if (getFrom() != null) {
       smtp.setFrom(getFrom());
     }
-
     MetadataCollection metadataSubset = getMetadataFilter().filter(msg);
     for (MetadataElement element : metadataSubset) {
       smtp.addMailHeader(element.getKey(), element.getValue());
     }
     return smtp;
-  }
-
-  /**
-   * Set the from address.
-   *
-   * @param fromAddress the from address
-   */
-  public void setFrom(String fromAddress) {
-    from = fromAddress;
-  }
-
-  /**
-   * Get the from address.
-   *
-   * @return the from address.
-   */
-  public String getFrom() {
-    return from;
-  }
-
-  /**
-   * Get the session properties used by this SMTP Producer.
-   *
-   * @return the properties.
-   */
-  public KeyValuePairSet getSessionProperties() {
-    return sessionProperties;
-  }
-
-  /**
-   * Set the session properties to this SMTP Producer.
-   *
-   * @param kp the properties
-   */
-  public void setSessionProperties(KeyValuePairSet kp) {
-    sessionProperties = Args.notNull(kp, "sessionProperties");
-  }
-
-  /**
-   * @return the bccList
-   */
-  public String getBccList() {
-    return bccList;
-  }
-
-  /**
-   * Comma separated list of email addresses to BCC.
-   *
-   * @param bcc the bccList to set
-   */
-  public void setBccList(String bcc) {
-    bccList = bcc;
-  }
-
-  public MetadataFilter getMetadataFilter() {
-    return metadataFilter;
-  }
-
-  /**
-   * Specify the {@link com.adaptris.core.AdaptrisMessage} metadata keys that will be sent as headers for the mail message.
-   * <p>
-   * Any metadata that is returned by this filter will be sent as headers.
-   * </p>
-   *
-   * @param metadataFilter the filter defaults to {@link RemoveAllMetadataFilter}
-   * @see MetadataFilter
-   * @since 3.0.2
-   */
-  public void setMetadataFilter(MetadataFilter metadataFilter) {
-    this.metadataFilter = Args.notNull(metadataFilter, "metadataFilter");
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  /**
-   * Set the password to be used with this producer implementation.
-   * <p>
-   * If you specify the username and password in the URL for the SMTP server then does not lend itself to being encrypted. Specify
-   * the password here if you wish to use {@link com.adaptris.security.password.Password#decode(String)} to decode the password.
-   * </p>
-   *
-   * @param pw the password which will be overriden if a password is present in the URL.
-   */
-  public void setPassword(String pw) {
-    password = pw;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  /**
-   * Set the username to be used with this producer implementation.
-   *
-   * @param name the username which will be overriden if a username is present in the URL.
-   */
-  public void setUsername(String name) {
-    username = name;
   }
 
   @Override

--- a/src/main/java/com/adaptris/core/mail/SendEmail.java
+++ b/src/main/java/com/adaptris/core/mail/SendEmail.java
@@ -1,0 +1,80 @@
+package com.adaptris.core.mail;
+
+import org.apache.commons.lang3.StringUtils;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.NullConnection;
+import com.adaptris.core.ProduceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.mail.SmtpClient;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Replaces DefaultSmtpProducer if you just want to send an email.
+ */
+@XStreamAlias("send-email")
+@AdapterComponent
+@ComponentProfile(summary = "Send an email", tag = "email,smtp,mail",
+    recommended = {NullConnection.class})
+@DisplayOrder(
+    order = {"to", "from", "subject", "ccList", "bccList", "smtpUrl", "username", "password",
+        "contentType", "contentEncoding"})
+@NoArgsConstructor
+public class SendEmail extends MailProducer {
+
+  /**
+   * The Content-Type of the email that will be sent.
+   * <p>
+   * The Content-Type may be any arbitary string such as application/edi-x12, however if no
+   * appropriate {@code DataContentHandler} is installed, then the results can be undefined. It
+   * defaults to {@code text/plain} if not specified.
+   * </p>
+   */
+  @AdvancedConfig
+  @Getter
+  @Setter
+  @InputFieldHint(expression = true)
+  @InputFieldDefault(value = EmailConstants.TEXT_PLAIN)
+  private String contentType;
+  /**
+   * The encoding of the email that will be sent.
+   * <p>
+   * Available Content-Encoding schemes that are supported are the same as those specified in
+   * RFC2045 or those supported by jakarta mail. They include {@code base64, quoted-printable, 7bit,
+   * 8bit and binary}. The default is {@code base64} if not otherwise specified to avoid encoding
+   * issues.
+   * </p>
+   */
+  @AdvancedConfig
+  @InputFieldHint(expression = true)
+  @InputFieldDefault(value = "base64")
+  @Getter
+  @Setter
+  private String contentEncoding = null;
+
+  @Override
+  protected void doProduce(AdaptrisMessage msg, String toAddresses) throws ProduceException {
+    try {
+      SmtpClient smtp = getClient(msg, toAddresses);
+      smtp.setEncoding(resolve(msg, getContentEncoding(), "base64"));
+      smtp.setMessage(encode(msg), resolve(msg, getContentType(), EmailConstants.TEXT_PLAIN));
+      smtp.send();
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapProduceException(e);
+    }
+  }
+
+  protected static String resolve(AdaptrisMessage msg, String configured, String defaultValue) {
+    String result = StringUtils.defaultIfBlank(configured, defaultValue);
+    return msg.resolve(result);
+  }
+
+}

--- a/src/main/java/com/adaptris/core/mail/SendEmailAttachment.java
+++ b/src/main/java/com/adaptris/core/mail/SendEmailAttachment.java
@@ -1,0 +1,113 @@
+package com.adaptris.core.mail;
+
+import static com.adaptris.core.mail.SendEmail.resolve;
+import java.nio.charset.StandardCharsets;
+import javax.validation.Valid;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageEncoder;
+import com.adaptris.core.NullConnection;
+import com.adaptris.core.ProduceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.mail.SmtpClient;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Replacement for {@link DefaultSmtpProducer} if you want to send an email with the payload as an
+ * attachment.
+ * <p>
+ * Note that this producer will ignore any configured {@link AdaptrisMessageEncoder}. The template
+ * if specified will be assumed to be plain text.
+ * </p>
+ *
+ */
+@XStreamAlias("send-email-attachment")
+@AdapterComponent
+@ComponentProfile(summary = "Send an email", tag = "email,smtp,mail",
+    recommended = {NullConnection.class})
+@DisplayOrder(order = {"to", "from", "subject", "body", "ccList", "bccList", "smtpUrl", "username",
+    "password", "contentType", "contentEncoding"})
+@NoArgsConstructor
+public class SendEmailAttachment extends MailProducer {
+
+  private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+
+  /**
+   * The Content-Type of the email that will be sent.
+   * <p>
+   * The Content-Type may be any arbitary string such as application/edi-x12, however if no
+   * appropriate {@code DataContentHandler} is installed, then the results can be undefined. It
+   * defaults to {@code application/octet-stream} if not specified.
+   * </p>
+   */
+  @InputFieldDefault(value = DEFAULT_CONTENT_TYPE)
+  @Getter
+  @Setter
+  @InputFieldHint(expression = true)
+  private String contentType = DEFAULT_CONTENT_TYPE;
+  /**
+   * The encoding of the email that will be sent.
+   * <p>
+   * Available Content-Encoding schemes that are supported are the same as those specified in
+   * RFC2045 or those supported by jakarta mail. They include {@code base64, quoted-printable, 7bit,
+   * 8bit and binary}. The default is {@code base64} if not otherwise specified to avoid encoding
+   * issues.
+   * </p>
+   */
+  @AdvancedConfig
+  @InputFieldDefault(value = "base64")
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  private String contentEncoding = null;
+
+  /**
+   * If specified, then this will be used as the filename for the attachment
+   * <p>
+   * Defaults to the message unique id if not explicitly specified.
+   * </p>
+   */
+  @AdvancedConfig
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  private String filename = null;
+
+  /**
+   * What is going to be the body of your message since the payload will be an attachment?
+   * <p>
+   * The template if specified will be assumed to be plain text
+   * </p>
+   */
+  @Getter
+  @Setter
+  @Valid
+  private DataInputParameter<String> body;
+
+  @Override
+  protected void doProduce(AdaptrisMessage msg, String toAddresses) throws ProduceException {
+    try {
+      SmtpClient smtp = getClient(msg, toAddresses);
+      if (getBody() != null) {
+        smtp.setMessage(msg.resolve(getBody().extract(msg), true).getBytes(StandardCharsets.UTF_8));
+      }
+      String filename = resolve(msg, getFilename(), msg.getUniqueId());
+      String contentType = resolve(msg, getContentType(), DEFAULT_CONTENT_TYPE);
+      String contentEncoding = resolve(msg, getContentEncoding(), "base64");
+      smtp.addAttachment(encode(msg), filename, contentType, contentEncoding);
+      smtp.send();
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapProduceException(e);
+    }
+  }
+
+}

--- a/src/main/java/com/adaptris/core/mail/attachment/MailContent.java
+++ b/src/main/java/com/adaptris/core/mail/attachment/MailContent.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,14 +17,10 @@
 package com.adaptris.core.mail.attachment;
 
 import java.security.MessageDigest;
-
 import javax.mail.internet.ContentType;
 import javax.mail.internet.ParseException;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import com.adaptris.util.text.Conversion;
 
 /**
  * Representation of the body of a mail message.
@@ -79,7 +75,7 @@ public class MailContent {
       MessageDigest md = MessageDigest.getInstance("MD5");
       md.update(b);
       byte[] hash = md.digest();
-      result = Conversion.byteArrayToBase64String(hash);
+      result = java.util.Base64.getEncoder().encodeToString(hash);
     }
     catch (Exception e) {
       ;

--- a/src/main/java/com/adaptris/core/mail/attachment/XmlAttachmentHandler.java
+++ b/src/main/java/com/adaptris/core/mail/attachment/XmlAttachmentHandler.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,7 +50,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * contain namespaces, then Saxon can cause merry havoc in the sense that {@code //NonNamespaceXpath} doesn't work if the document
  * has namespaces in it. We have included a shim so that behaviour can be toggled based on what you have configured.
  * </p>
- * 
+ *
  * @see XPath#newXPathInstance(DocumentBuilderFactoryBuilder, NamespaceContext)
  * @config mail-xml-attachment-handler
  */
@@ -200,12 +200,12 @@ public class XmlAttachmentHandler implements AttachmentHandler {
    * <li>The key is the namespace prefix</li>
    * <li>The value is the namespace uri</li>
    * </ul>
-   * 
+   *
    * @param kvps the namespace context
    * @see SimpleNamespaceContext#create(KeyValuePairSet)
    */
   public void setNamespaceContext(KeyValuePairSet kvps) {
-    this.namespaceContext = kvps;
+    namespaceContext = kvps;
   }
 
   public String getAttachmentEncoding() {
@@ -214,11 +214,11 @@ public class XmlAttachmentHandler implements AttachmentHandler {
 
   /**
    * Specify the Content-Transfer-Encoding to be associated with each attachment.
-   * 
+   *
    * @param e the encoding; default is base64 if not specified.
    */
   public void setAttachmentEncoding(String e) {
-    this.attachmentEncoding = e;
+    attachmentEncoding = e;
   }
 
   public XmlAttachmentHandler withAttachmentEncoding(String s) {
@@ -231,10 +231,10 @@ public class XmlAttachmentHandler implements AttachmentHandler {
   }
 
   public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xml) {
-    this.xmlDocumentFactoryConfig = xml;
+    xmlDocumentFactoryConfig = xml;
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/src/main/java/com/adaptris/core/mail/attachment/XmlBodyHandler.java
+++ b/src/main/java/com/adaptris/core/mail/attachment/XmlBodyHandler.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,11 +42,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * contain namespaces, then Saxon can cause merry havoc in the sense that {@code //NonNamespaceXpath} doesn't work if the document
  * has namespaces in it. We have included a shim so that behaviour can be toggled based on what you have configured.
  * </p>
- * 
+ *
  * @see XPath#newXPathInstance(DocumentBuilderFactoryBuilder, NamespaceContext)
- * 
+ *
  * @config mail-xml-body-handler
- * 
+ *
  */
 @XStreamAlias("mail-xml-body-handler")
 public class XmlBodyHandler implements BodyHandler {
@@ -168,12 +168,12 @@ public class XmlBodyHandler implements BodyHandler {
    * <li>The key is the namespace prefix</li>
    * <li>The value is the namespace uri</li>
    * </ul>
-   * 
+   *
    * @param kvps the namespace context
    * @see SimpleNamespaceContext#create(KeyValuePairSet)
    */
   public void setNamespaceContext(KeyValuePairSet kvps) {
-    this.namespaceContext = kvps;
+    namespaceContext = kvps;
   }
 
   public DocumentBuilderFactoryBuilder getXmlDocumentFactoryConfig() {
@@ -181,10 +181,10 @@ public class XmlBodyHandler implements BodyHandler {
   }
 
   public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xml) {
-    this.xmlDocumentFactoryConfig = xml;
+    xmlDocumentFactoryConfig = xml;
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/src/main/java/com/adaptris/core/mail/attachment/XmlMailCreator.java
+++ b/src/main/java/com/adaptris/core/mail/attachment/XmlMailCreator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,14 +19,11 @@ package com.adaptris.core.mail.attachment;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
@@ -35,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * MailCreator implementation that assumes the AdaptrisMessage is an XML document.
- * 
+ *
  * @config mail-xml-content-creator
  * @author lchan
  * @author $Author: lchan $
@@ -129,11 +126,12 @@ public class XmlMailCreator implements MailContentCreator {
 
 
   public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xml) {
-    this.xmlDocumentFactoryConfig = xml;
+    xmlDocumentFactoryConfig = xml;
   }
 
   DocumentBuilder documentBuilder() throws ParserConfigurationException {
-    DocumentBuilderFactoryBuilder fac = DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    DocumentBuilderFactoryBuilder fac =
+        DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
     return fac.build().newDocumentBuilder();
   }
 }

--- a/src/test/java/com/adaptris/core/mail/SendEmailAttachmentTest.java
+++ b/src/test/java/com/adaptris/core/mail/SendEmailAttachmentTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.mail;
+
+import static com.adaptris.mail.JunitMailHelper.DEFAULT_RECEIVER;
+import static com.adaptris.mail.JunitMailHelper.DEFAULT_SENDER;
+import static com.adaptris.mail.JunitMailHelper.testsEnabled;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import javax.mail.internet.MimeMessage;
+import org.junit.Assume;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.NullConnection;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.mail.JunitMailHelper;
+import com.adaptris.mail.MessageParser;
+import com.adaptris.util.KeyValuePair;
+import com.icegreen.greenmail.smtp.SmtpServer;
+import com.icegreen.greenmail.util.GreenMail;
+
+public class SendEmailAttachmentTest extends MailProducerExample {
+
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    return null;
+  }
+
+
+
+  @Test
+  public void testProduceAsAttachment() throws Exception {
+    Assume.assumeTrue(testsEnabled());
+    GreenMail gm = JunitMailHelper.startServer();
+    try {
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JunitMailHelper.DEFAULT_PAYLOAD);
+      StandaloneProducer producer = createProducerForTests(gm);
+      SendEmailAttachment mailer = (SendEmailAttachment) producer.getProducer();
+      mailer.setContentType(EmailConstants.TEXT_PLAIN);
+      ServiceCase.execute(producer, msg);
+
+      gm.waitForIncomingEmail(1);
+      MimeMessage[] msgs = gm.getReceivedMessages();
+      assertEquals(1, msgs.length);
+      MimeMessage mailmsg = msgs[0];
+      JunitMailHelper.assertFrom(mailmsg, DEFAULT_SENDER);
+      JunitMailHelper.assertTo(mailmsg, DEFAULT_RECEIVER);
+      MessageParser mp = new MessageParser(mailmsg);
+      assertTrue(mp.hasAttachments());
+    }
+    finally {
+      JunitMailHelper.stopServer(gm);
+    }
+  }
+
+  @Test
+  public void testProduceAsAttachmentWithFilename() throws Exception {
+    Assume.assumeTrue(testsEnabled());
+    GreenMail gm = JunitMailHelper.startServer();
+    try {
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JunitMailHelper.DEFAULT_PAYLOAD);
+      StandaloneProducer producer = createProducerForTests(gm);
+      SendEmailAttachment mailer = (SendEmailAttachment) producer.getProducer();
+      mailer.setContentType("text/xml");
+      mailer.setFilename("%message{filename}");
+      msg.addMetadata("filename", "filename.txt");
+      ServiceCase.execute(producer, msg);
+
+      gm.waitForIncomingEmail(1);
+      MimeMessage[] msgs = gm.getReceivedMessages();
+      assertEquals(1, msgs.length);
+      MimeMessage mailmsg = msgs[0];
+      JunitMailHelper.assertFrom(mailmsg, DEFAULT_SENDER);
+      JunitMailHelper.assertTo(mailmsg, DEFAULT_RECEIVER);
+      MessageParser mp = new MessageParser(mailmsg);
+      assertTrue(mp.hasAttachments());
+      assertEquals("filename.txt", mp.nextAttachment().getFilename());
+    }
+    finally {
+      JunitMailHelper.stopServer(gm);
+    }
+  }
+
+  @Test
+  public void testProduceAsAttachmentWithMetadataAttachmentContentType() throws Exception {
+    Assume.assumeTrue(testsEnabled());
+    GreenMail gm = JunitMailHelper.startServer();
+    try {
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JunitMailHelper.DEFAULT_PAYLOAD);
+      StandaloneProducer producer = createProducerForTests(gm);
+      SendEmailAttachment mailer = (SendEmailAttachment) producer.getProducer();
+      mailer.setContentType("%message{contentType}");
+      msg.addMetadata("contentType", EmailConstants.TEXT_PLAIN);
+      ServiceCase.execute(producer, msg);
+
+      gm.waitForIncomingEmail(1);
+      MimeMessage[] msgs = gm.getReceivedMessages();
+      assertEquals(1, msgs.length);
+      MimeMessage mailmsg = msgs[0];
+      JunitMailHelper.assertFrom(mailmsg, DEFAULT_SENDER);
+      JunitMailHelper.assertTo(mailmsg, DEFAULT_RECEIVER);
+      MessageParser mp = new MessageParser(mailmsg);
+      assertTrue(mp.hasAttachments());
+      assertEquals(EmailConstants.TEXT_PLAIN, mp.nextAttachment().getContentType());
+    }
+    finally {
+      JunitMailHelper.stopServer(gm);
+    }
+  }
+
+  @Test
+  public void testProduceAsAttachmentWithTemplate() throws Exception {
+    Assume.assumeTrue(testsEnabled());
+    GreenMail gm = JunitMailHelper.startServer();
+    try {
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(JunitMailHelper.DEFAULT_PAYLOAD);
+      StandaloneProducer producer = createProducerForTests(gm);
+      SendEmailAttachment mailer = (SendEmailAttachment) producer.getProducer();
+      mailer.setBody(new ConstantDataInputParameter("This is the body"));
+      ServiceCase.execute(producer, msg);
+
+      gm.waitForIncomingEmail(1);
+      MimeMessage[] msgs = gm.getReceivedMessages();
+      assertEquals(1, msgs.length);
+      MimeMessage mailmsg = msgs[0];
+      JunitMailHelper.assertFrom(mailmsg, DEFAULT_SENDER);
+      JunitMailHelper.assertTo(mailmsg, DEFAULT_RECEIVER);
+      MessageParser mp = new MessageParser(mailmsg);
+      assertTrue(mp.hasAttachments());
+      assertEquals("This is the body", new String(mp.getMessage()));
+    }
+    finally {
+      JunitMailHelper.stopServer(gm);
+    }
+  }
+
+  /**
+   * @see com.adaptris.core.ExampleConfigCase#retrieveObjectForSampleConfig()
+   */
+  @Override
+  protected List<StandaloneProducer> retrieveObjectsForSampleConfig() {
+    List<StandaloneProducer> result = new ArrayList<>();
+    SendEmailAttachment smtp = new SendEmailAttachment();
+    smtp.setTo("user@domain");
+    smtp.getSessionProperties().addKeyValuePair(new KeyValuePair("mail.smtp.starttls.enable", "true"));
+    smtp.setSubject("Configured subject");
+    smtp.setSmtpUrl("smtp://localhost:25");
+    smtp.setCcList("user@domain, user@domain");
+    RegexMetadataFilter filter = new RegexMetadataFilter();
+    filter.addIncludePattern("X-MyHeaders.*");
+    smtp.setMetadataFilter(filter);
+    result.add(new StandaloneProducer(smtp));
+
+    SendEmailAttachment smtps = new SendEmailAttachment();
+    smtps.setTo("user@domain");
+    smtps.getSessionProperties().addKeyValuePair(new KeyValuePair("mail.smtp.starttls.enable", "true"));
+    smtps.setSubject("Configured subject");
+    smtps.setSmtpUrl("smtps://username%40gmail.com:mypassword;@smtp.gmail.com:465");
+    smtps.setCcList("user@domain, user@domain");
+    filter = new RegexMetadataFilter();
+    filter.addIncludePattern("X-MyHeaders.*");
+    smtps.setMetadataFilter(filter);
+    result.add(new StandaloneProducer(smtps));
+
+    return result;
+  }
+
+  @Override
+  protected String createBaseFileName(Object object) {
+    String basename = super.createBaseFileName(object);
+    StandaloneProducer c = (StandaloneProducer) object;
+    String s = ((SendEmailAttachment) c.getProducer()).getSmtpUrl();
+    int pos = s.indexOf(":");
+    if (pos > 0) {
+      basename = basename + "-" + s.substring(0, pos).toUpperCase();
+    }
+    return basename;
+  }
+
+  protected StandaloneProducer createProducerForTests(GreenMail gm) {
+    SendEmailAttachment smtp = new SendEmailAttachment();
+    SmtpServer server = gm.getSmtp();
+    String smtpUrl = server.getProtocol() + "://localhost:" + server.getPort();
+    smtp.setSmtpUrl(smtpUrl);
+    smtp.setSubject("Junit Test for com.adaptris.core.mail");
+    smtp.setFrom(JunitMailHelper.DEFAULT_SENDER);
+    smtp.setContentType("plain/text");
+    smtp.setTo(JunitMailHelper.DEFAULT_RECEIVER);
+    return new StandaloneProducer(new NullConnection(), smtp);
+  }
+
+}

--- a/src/test/java/com/adaptris/core/mail/attachment/MultiAttachmentProducerMimeTest.java
+++ b/src/test/java/com/adaptris/core/mail/attachment/MultiAttachmentProducerMimeTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,7 @@ package com.adaptris.core.mail.attachment;
 
 import static com.adaptris.core.mail.attachment.MimeMailCreatorTest.create;
 import static com.adaptris.core.services.mime.MimeJunitHelper.PAYLOAD_2;
-
 import org.junit.Before;
-
-import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.mail.MailProducerExample;
 import com.adaptris.core.metadata.RegexMetadataFilter;
@@ -43,10 +40,7 @@ public class MultiAttachmentProducerMimeTest extends MailProducerExample {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    ConfiguredProduceDestination dest = new ConfiguredProduceDestination();
-    dest.setDestination("user@domain");
-
-    producer.setDestination(dest);
+    producer.setTo("user@domain");
     producer.setSubject("Configured subject");
     producer.setSmtpUrl("smtp://localhost:25");
     producer.setCcList("user@domain, user@domain");


### PR DESCRIPTION
## Motivation

Removing things that are marked for removal in 3.11.0

## Modification

Since the behaviour of DefaultSmtpProducer is very hard to unpick from its associated metadata, this class now deprecated in favour of 2 new producers
- SendEmail which sends the current payload as the mail
- SendEmailAttachment which sends the current payload as an attachment with a simple template you can apply (via DataInputParameter).
- Remove use of Deprecated newInstance() DocBuilder methods and Conversion.toBase64

## Result

Users aren't broken, but have 2 new producers.

