### PR TITLE
INTERLOK-3555 #comment Update the pom url to point to the right doc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,7 +313,7 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Integration with mail servers using javamail and apache mail libraries")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/cookbook-email.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/cookbook/cookbook-email")
         properties.appendNode("target", "3.9.0+")
         properties.appendNode("tags", "email,pop3,pop3s,imap,imaps")
         properties.appendNode("license", "false")

--- a/build.gradle
+++ b/build.gradle
@@ -312,8 +312,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Integration with mail servers using javamail and apache mail libraries")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/cookbook/cookbook-email")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/cookbook/cookbook-email")
         properties.appendNode("target", "3.9.0+")
         properties.appendNode("tags", "email,pop3,pop3s,imap,imaps")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation
The documentation was broken since we changed the doc site

## Modification
Fix the doc url

## Result
The pom has a correct doc url and a new repo url

## Testing
Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.