### PR TITLE
INTERLOK-3737 Hide the password when logging the smtp url

### DIFF
--- a/src/main/java/com/adaptris/core/mail/URLNameHelper.java
+++ b/src/main/java/com/adaptris/core/mail/URLNameHelper.java
@@ -1,0 +1,87 @@
+package com.adaptris.core.mail;
+
+import javax.mail.URLName;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class URLNameHelper {
+
+  private URLNameHelper() {
+  }
+
+  /**
+   * A toString method that stringify the URLName but hide the password.
+   * It's very similar to {@link URLName#toString()} but it's meant to hide the password for logging.
+   * It also does not encode the username.
+   *
+   * @param url URLName
+   * @return url safe string
+   */
+  public static String toSafeString(URLName url) {
+    StringBuilder tempURL = new StringBuilder();
+
+    addProtocol(url, tempURL);
+
+    // Empty host are allowed (file:///)
+    if (StringUtils.isNotBlank(url.getUsername()) || url.getHost() != null) {
+      tempURL.append("//");
+
+      addCredentials(url, tempURL);
+      addHost(url, tempURL);
+      addPort(url, tempURL);
+
+      if (StringUtils.isNotBlank(url.getFile())) {
+        tempURL.append("/");
+      }
+    }
+
+    addFile(url, tempURL);
+    addRef(url, tempURL);
+    return tempURL.toString();
+  }
+
+  private static void addProtocol(URLName url, StringBuilder tempURL) {
+    if (StringUtils.isNotBlank(url.getProtocol())) {
+      tempURL.append(url.getProtocol());
+      tempURL.append(":");
+    }
+  }
+
+  private static void addCredentials(URLName url, StringBuilder tempURL) {
+    if (StringUtils.isNotBlank(url.getUsername())) {
+      tempURL.append(url.getUsername());
+      if (StringUtils.isNotBlank(url.getPassword())) {
+        tempURL.append(":");
+        tempURL.append("*****");
+      }
+      tempURL.append("@");
+    }
+  }
+
+  private static void addHost(URLName url, StringBuilder tempURL) {
+    if (StringUtils.isNotBlank(url.getHost())) {
+      tempURL.append(url.getHost());
+    }
+  }
+
+  private static void addPort(URLName url, StringBuilder tempURL) {
+    if (url.getPort() != -1) {
+      tempURL.append(":");
+      tempURL.append(Integer.toString(url.getPort()));
+    }
+  }
+
+  private static void addFile(URLName url, StringBuilder tempURL) {
+    if (StringUtils.isNotBlank(url.getFile())) {
+      tempURL.append(url.getFile());
+    }
+  }
+
+  private static void addRef(URLName url, StringBuilder tempURL) {
+    if (StringUtils.isNotBlank(url.getRef())) {
+      tempURL.append("#");
+      tempURL.append(url.getRef());
+    }
+  }
+
+}

--- a/src/main/java/com/adaptris/core/mail/attachment/XmlMailCreator.java
+++ b/src/main/java/com/adaptris/core/mail/attachment/XmlMailCreator.java
@@ -19,11 +19,12 @@ package com.adaptris.core.mail.attachment;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.w3c.dom.Document;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
@@ -42,7 +43,6 @@ public class XmlMailCreator implements MailContentCreator {
 
   private AttachmentHandler attachmentHandler;
   private BodyHandler bodyHandler;
-  private transient Logger logR = LoggerFactory.getLogger(this.getClass());
   @AdvancedConfig
   private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
 
@@ -58,7 +58,7 @@ public class XmlMailCreator implements MailContentCreator {
     if (attachmentHandler == null) {
       throw new MailException("No way of selecting the Attachments");
     }
-    List<MailAttachment> result = new ArrayList<MailAttachment>();
+    List<MailAttachment> result = new ArrayList<>();
     try (InputStream in = msg.getInputStream()) {
       Document d = documentBuilder().parse(in);
       result = attachmentHandler.resolve(d);

--- a/src/main/java/com/adaptris/mail/MatchProxyFactory.java
+++ b/src/main/java/com/adaptris/mail/MatchProxyFactory.java
@@ -17,12 +17,9 @@
 package com.adaptris.mail;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class MatchProxyFactory {
 
-  private static transient Logger log = LoggerFactory.getLogger(MatchProxy.class);
   public static final String DEFAULT_REGEXP_STYLE = "Regex";
 
   protected enum ProxyBuilder {

--- a/src/main/java/com/adaptris/mail/SmtpClient.java
+++ b/src/main/java/com/adaptris/mail/SmtpClient.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.mail;
 
@@ -20,8 +20,11 @@ import javax.mail.Transport;
 import javax.mail.URLName;
 import javax.mail.event.TransportEvent;
 import javax.mail.event.TransportListener;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.adaptris.core.mail.URLNameHelper;
 
 /**
  * The Adaptris SMTP client.
@@ -102,7 +105,7 @@ public final class SmtpClient extends MailSenderImp implements TransportListener
 
     try {
       Transport tr = session.getTransport(smtpUrl);
-      log.trace("Attempting to send {} using SMTP {}", message.getMessageID(), smtpUrl);
+      log.trace("Attempting to send {} using SMTP {}", message.getMessageID(), URLNameHelper.toSafeString(smtpUrl));
       if (smtpUrl.getUsername() != null) {
         tr.connect(smtpUrl.getHost(), smtpUrl.getPort(), smtpUrl.getUsername(),
             smtpUrl.getPassword());

--- a/src/test/java/com/adaptris/mail/URLNameHelperTest.java
+++ b/src/test/java/com/adaptris/mail/URLNameHelperTest.java
@@ -1,0 +1,68 @@
+package com.adaptris.mail;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+
+import javax.mail.URLName;
+
+import org.junit.Test;
+
+import com.adaptris.core.mail.URLNameHelper;
+
+public class URLNameHelperTest {
+
+  @Test
+  public void testToSafeString() throws MalformedURLException {
+    URLName url = new URLName("smtp://smtp.gmail.com:587");
+
+    assertEquals("smtp://smtp.gmail.com:587", URLNameHelper.toSafeString(url));
+  }
+
+  @Test
+  public void testToSafeStringNoPort() throws MalformedURLException {
+    URLName url = new URLName("smtp://smtp.gmail.com");
+
+    assertEquals("smtp://smtp.gmail.com", URLNameHelper.toSafeString(url));
+  }
+
+  @Test
+  public void testToSafeStringNoProtocolNoPort() throws MalformedURLException {
+    URLName url = new URLName("smtp.gmail.com");
+
+    assertEquals("smtp.gmail.com", URLNameHelper.toSafeString(url));
+  }
+
+  @Test
+  public void testToSafeStringHiddenPassword() throws MalformedURLException {
+    URLName url = new URLName("smtp://username:MySecretPassword@smtp.gmail.com:587");
+
+    assertEquals("smtp://username:*****@smtp.gmail.com:587", URLNameHelper.toSafeString(url));
+  }
+
+  @Test
+  public void testToSafeStringUsernameNotEncoded() throws MalformedURLException {
+    URLName url = new URLName("smtp://username%40host.local@smtp.gmail.com:587");
+
+    assertEquals("smtp://username@host.local@smtp.gmail.com:587", URLNameHelper.toSafeString(url));
+  }
+
+  @Test
+  public void testToSafeStringNoHost() throws MalformedURLException {
+    URLName url = new URLName("file:/path/to/file");
+
+    assertEquals("file:/path/to/file", URLNameHelper.toSafeString(url));
+
+    url = new URLName("file:///path/to/file");
+
+    assertEquals("file:///path/to/file", URLNameHelper.toSafeString(url));
+  }
+
+  @Test
+  public void testToSafeStringWithRef() throws MalformedURLException {
+    URLName url = new URLName("http://host.local/context#ref");
+
+    assertEquals("http://host.local/context#ref", URLNameHelper.toSafeString(url));
+  }
+
+}


### PR DESCRIPTION
## Motivation

The password of the email account used to send an email is show when trace logging the smtp url used.

## Modification

- Add a new helper class that that does a toString of a URLName but hide the password.
- Add tests for the helper class.
- Remove some unused code.

## Result

Everything should work the same but the password is replaced by *****.

## Testing

- Use the project from https://gitlab.agb.rbxd.ds/interlok/testing/mail-testing
- You may want to change some of the variables in variables.properties
- Build it (`./gradlew clean assemble`) and in build/distribution replace interlok-mail.jar from the lib dir by the one built from this PR's branch.
- Start the adapter (`java -jar lib/interlok-boot.jar`).
- When the adapter starts you should see some log like:
```
TRACE [to-mail@to-mail] [c.a.m.SmtpClient] Attempting to send <78135400.1.16149t> using SMTP smtp://interlok.testing+from@gmail.com:*****@smtp.gmail.com:587
```
