### PR TITLE
INTERLOK-3566 Remove Destination references

### DIFF
--- a/src/main/java/com/adaptris/core/mail/MailConsumerImp.java
+++ b/src/main/java/com/adaptris/core/mail/MailConsumerImp.java
@@ -16,30 +16,14 @@
 
 package com.adaptris.core.mail;
 
-import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.split;
-import java.io.Closeable;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.mail.internet.MimeMessage;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisPollingConsumer;
-import com.adaptris.core.ConsumeDestination;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
-import com.adaptris.core.util.DestinationHelper;
-import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.mail.JavamailReceiverFactory;
 import com.adaptris.mail.MailException;
@@ -48,6 +32,21 @@ import com.adaptris.mail.MailReceiverFactory;
 import com.adaptris.mail.MatchProxyFactory;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.mail.internet.MimeMessage;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.split;
 
 /**
  * Email implementation of the AdaptrisMessageConsumer interface.
@@ -107,23 +106,12 @@ public abstract class MailConsumerImp extends AdaptrisPollingConsumer{
   private MailHeaderHandler headerHandler;
 
   /**
-   * The consume destination contains the MailboxURL that we poll.
-   *
-   */
-  @Getter
-  @Setter
-  @Deprecated
-  @Valid
-  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'mailbox-url' instead", groups = Deprecated.class)
-  private ConsumeDestination destination;
-
-  /**
    * The Mailbox specified as a URL.
    *
    */
   @Getter
   @Setter
-  // Needs to be @NotBlank when destination is removed.
+  @NotBlank
   private String mailboxUrl;
 
   /**
@@ -138,7 +126,6 @@ public abstract class MailConsumerImp extends AdaptrisPollingConsumer{
 
 
   protected transient MailReceiver mbox;
-  private transient boolean destinationWarningLogged;
 
   public MailConsumerImp() {
     setRegularExpressionStyle(MatchProxyFactory.DEFAULT_REGEXP_STYLE);
@@ -149,10 +136,6 @@ public abstract class MailConsumerImp extends AdaptrisPollingConsumer{
 
   @Override
   protected void prepareConsumer() throws CoreException {
-    DestinationHelper.logWarningIfNotNull(destinationWarningLogged,
-        () -> destinationWarningLogged = true, getDestination(),
-        "{} uses destination, use path + methods instead", LoggingHelper.friendlyName(this));
-    DestinationHelper.mustHaveEither(getMailboxUrl(), getDestination());
   }
 
   @Override
@@ -379,15 +362,15 @@ public abstract class MailConsumerImp extends AdaptrisPollingConsumer{
 
   @Override
   protected String newThreadName() {
-    return DestinationHelper.threadName(retrieveAdaptrisMessageListener(), getDestination());
+    return retrieveAdaptrisMessageListener().friendlyName();
   }
 
   protected String mailboxUrl() {
-    return DestinationHelper.consumeDestination(getMailboxUrl(), getDestination());
+    return getMailboxUrl();
   }
 
   protected String filterExpression() {
-    return DestinationHelper.filterExpression(getFilterExpression(), getDestination());
+    return getFilterExpression();
   }
 
 }

--- a/src/main/java/com/adaptris/core/mail/MailProducer.java
+++ b/src/main/java/com/adaptris/core/mail/MailProducer.java
@@ -16,27 +16,18 @@
 
 package com.adaptris.core.mail;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
-import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ProduceOnlyProducerImp;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.RemoveAllMetadataFilter;
 import com.adaptris.core.util.Args;
-import com.adaptris.core.util.DestinationHelper;
-import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.mail.MailException;
 import com.adaptris.mail.SmtpClient;
@@ -46,6 +37,11 @@ import com.adaptris.util.KeyValuePairSet;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 /**
  * Abstract implementation of the AdaptrisMessageProducer interface for handling Email.
@@ -66,8 +62,6 @@ import lombok.Setter;
  * headers.
  * </p>
  *
- * @see CoreConstants#EMAIL_SUBJECT
- * @see CoreConstants#EMAIL_CC_LIST
  */
 public abstract class MailProducer extends ProduceOnlyProducerImp {
 
@@ -167,26 +161,14 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
   private String username;
 
   /**
-   * The destination is a comma separated list of {@code TO} addresses.
-   *
-   */
-  @Getter
-  @Setter
-  @Deprecated
-  @Valid
-  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'to' instead", groups = Deprecated.class)
-  private ProduceDestination destination;
-
-  /**
    * Comma separated list of email addresses to send to.
    */
   @InputFieldHint(expression = true)
   @Getter
   @Setter
-  // Needs to be @NotBlank when destination is removed.
+  @NotBlank
   private String to;
 
-  private transient boolean destWarning;
   public MailProducer() {
     sessionProperties = new KeyValuePairSet();
     setMetadataFilter(new RemoveAllMetadataFilter());
@@ -195,8 +177,6 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
   @Override
   public void prepare() throws CoreException {
     Args.notNull(getSmtpUrl(), "smtpUrl");
-    DestinationHelper.logWarningIfNotNull(destWarning, () -> destWarning = true, getDestination(),
-        "{} uses destination, use 'to' instead", LoggingHelper.friendlyName(this));
     // To is optional if you want to just use bcc !.
     // DestinationHelper.mustHaveEither(getPath(), getDestination());
 
@@ -257,7 +237,11 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
 
   @Override
   public String endpoint(AdaptrisMessage msg) throws ProduceException {
-    return DestinationHelper.resolveProduceDestination(getTo(), getDestination(), msg);
+    if (getTo() != null) {
+      return msg.resolveObject(getTo()).toString();
+    } else {
+      return null;
+    }
   }
 
 }

--- a/src/main/java/com/adaptris/core/mail/MailProducer.java
+++ b/src/main/java/com/adaptris/core/mail/MailProducer.java
@@ -237,11 +237,7 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
 
   @Override
   public String endpoint(AdaptrisMessage msg) throws ProduceException {
-    if (getTo() != null) {
-      return msg.resolveObject(getTo()).toString();
-    } else {
-      return null;
-    }
+    return msg.resolve(getTo());
   }
 
 }

--- a/src/main/java/com/adaptris/core/mail/attachment/MultiAttachmentSmtpProducer.java
+++ b/src/main/java/com/adaptris/core/mail/attachment/MultiAttachmentSmtpProducer.java
@@ -16,9 +16,6 @@
 
 package com.adaptris.core.mail.attachment;
 
-import java.util.List;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -28,7 +25,6 @@ import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
-import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.mail.EmailConstants;
 import com.adaptris.core.mail.MailProducer;
@@ -37,6 +33,10 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.mail.MailException;
 import com.adaptris.mail.SmtpClient;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
 
 /**
  * Implementation of the AdaptrisMessageProducer interface for handling email.

--- a/src/test/java/com/adaptris/core/mail/DefaultMailConsumerPartSelectorTest.java
+++ b/src/test/java/com/adaptris/core/mail/DefaultMailConsumerPartSelectorTest.java
@@ -16,10 +16,6 @@
 
 package com.adaptris.core.mail;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.Poller;
 import com.adaptris.core.QuartzCronPoller;
@@ -31,6 +27,10 @@ import com.adaptris.util.text.mime.PartSelector;
 import com.adaptris.util.text.mime.SelectByContentId;
 import com.adaptris.util.text.mime.SelectByHeader;
 import com.adaptris.util.text.mime.SelectByPosition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class DefaultMailConsumerPartSelectorTest extends MailConsumerExample {
 
@@ -44,8 +44,8 @@ public class DefaultMailConsumerPartSelectorTest extends MailConsumerExample {
   private StandaloneConsumer createConfigExample(Poller pollerImp, PartSelector partSelector) {
     DefaultMailConsumer pop3 = new DefaultMailConsumer();
     pop3.setPartSelector(partSelector);
-    pop3.setDestination(new ConfiguredConsumeDestination("pop3://username:password@server:110/INBOX", "FROM=optionalFilter,"
-        + "SUBJECT=optionalFilter," + "RECIPIENT=optionalFilter"));
+    pop3.setMailboxUrl("pop3://username:password@server:110/INBOX");
+    pop3.setFilterExpression("FROM=optionalFilter,SUBJECT=optionalFilter,RECIPIENT=optionalFilter");
     JavamailReceiverFactory fac = new JavamailReceiverFactory();
     fac.getSessionProperties().addKeyValuePair(new KeyValuePair("mail.smtp.starttls.enable", "true"));
     fac.getSessionProperties().addKeyValuePair(new KeyValuePair("mail.pop3.starttls.enable", "true"));

--- a/src/test/java/com/adaptris/core/mail/DefaultMailConsumerTest.java
+++ b/src/test/java/com/adaptris/core/mail/DefaultMailConsumerTest.java
@@ -14,17 +14,8 @@
 
 package com.adaptris.core.mail;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import java.io.FileInputStream;
-import java.util.List;
-import java.util.Properties;
-import javax.mail.Session;
-import javax.mail.internet.MimeMessage;
-import org.junit.Test;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
@@ -36,6 +27,16 @@ import com.adaptris.mail.Pop3ReceiverFactory;
 import com.adaptris.mail.Pop3sReceiverFactory;
 import com.adaptris.util.text.mime.NullPartSelector;
 import com.adaptris.util.text.mime.SelectByPosition;
+import org.junit.Test;
+
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class DefaultMailConsumerTest extends MailConsumerCase {
 
@@ -48,7 +49,7 @@ public class DefaultMailConsumerTest extends MailConsumerCase {
     sendMessage(mailServer());
     MockMessageListener mockListener = new MockMessageListener();
     MailConsumerImp imp = createConsumerForTests(mailServer());
-    imp.getDestination().setFilterExpression("*");
+    imp.setFilterExpression("*");
     StandaloneConsumer c = new StandaloneConsumer(imp);
     c.registerAdaptrisMessageListener(mockListener);
     LifecycleHelper.initAndStart(c);
@@ -66,7 +67,7 @@ public class DefaultMailConsumerTest extends MailConsumerCase {
     MockMessageListener mockListener = new MockMessageListener();
     DefaultMailConsumer imp = (DefaultMailConsumer) createConsumerForTests(mailServer());
     imp.setRegularExpressionStyle(REGEX_STYLE);
-    imp.getDestination().setFilterExpression("SUBJECT=.*");
+    imp.setFilterExpression("SUBJECT=.*");
     imp.setHeaderHandler(new MetadataMailHeaders().withHeaderFilter(new NoOpMetadataFilter()));
 
     StandaloneConsumer c = new StandaloneConsumer(imp);
@@ -100,8 +101,7 @@ public class DefaultMailConsumerTest extends MailConsumerCase {
     try {
       MockMessageProducer mockProducer = new MockMessageProducer();
       MailConsumerImp consumer = createConsumerForTests(mailServer(), new Pop3ReceiverFactory());
-      consumer.setDestination(new ConfiguredConsumeDestination(
-          "imap://localhost:" + mailServer().getPop3().getPort() + "/INBOX"));
+      consumer.setMailboxUrl("imap://localhost:" + mailServer().getPop3().getPort() + "/INBOX");
       a = createAdapter(consumer, mockProducer);
       a.requestStart();
     } finally {

--- a/src/test/java/com/adaptris/core/mail/DefaultMailProducerTest.java
+++ b/src/test/java/com/adaptris/core/mail/DefaultMailProducerTest.java
@@ -14,23 +14,8 @@
 
 package com.adaptris.core.mail;
 
-import static com.adaptris.mail.JunitMailHelper.DEFAULT_RECEIVER;
-import static com.adaptris.mail.JunitMailHelper.DEFAULT_SENDER;
-import static com.adaptris.mail.JunitMailHelper.testsEnabled;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import javax.mail.Header;
-import javax.mail.internet.MimeMessage;
-import org.junit.Assume;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.StandaloneProducer;
@@ -40,6 +25,22 @@ import com.adaptris.mail.MessageParser;
 import com.adaptris.util.KeyValuePair;
 import com.icegreen.greenmail.smtp.SmtpServer;
 import com.icegreen.greenmail.util.GreenMail;
+import org.junit.Assume;
+import org.junit.Test;
+
+import javax.mail.Header;
+import javax.mail.internet.MimeMessage;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import static com.adaptris.mail.JunitMailHelper.DEFAULT_RECEIVER;
+import static com.adaptris.mail.JunitMailHelper.DEFAULT_SENDER;
+import static com.adaptris.mail.JunitMailHelper.testsEnabled;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
 public class DefaultMailProducerTest extends MailProducerExample {
@@ -155,7 +156,7 @@ public class DefaultMailProducerTest extends MailProducerExample {
     msg.addMetadata("some-cc-address", "CarbonCopy@CarbonCopy.com");
     StandaloneProducer producer = createProducerForTests(gm);
     MailProducer mailer = (MailProducer) producer.getProducer();
-    mailer.setDestination(null);
+    mailer.setTo(null);
     mailer.setCcList("%message{some-cc-address}");
     ServiceCase.execute(producer, msg);
     gm.waitForIncomingEmail(1);
@@ -196,7 +197,7 @@ public class DefaultMailProducerTest extends MailProducerExample {
     msg.addMetadata("a-bcc-address", "BlindCarbonCopy@BlindCarbonCopy.com");
     StandaloneProducer producer = createProducerForTests(gm);
     MailProducer mailer = (MailProducer) producer.getProducer();
-    mailer.setDestination(null);
+    mailer.setTo(null);
     mailer.setBccList("%message{a-bcc-address}");
     ServiceCase.execute(producer, msg);
     gm.waitForIncomingEmail(1);
@@ -419,7 +420,7 @@ public class DefaultMailProducerTest extends MailProducerExample {
     smtp.setSubject("Junit Test for com.adaptris.core.mail");
     smtp.setFrom(JunitMailHelper.DEFAULT_SENDER);
     smtp.setContentType("plain/text");
-    smtp.setDestination(new ConfiguredProduceDestination(JunitMailHelper.DEFAULT_RECEIVER));
+    smtp.setTo(JunitMailHelper.DEFAULT_RECEIVER);
     return new StandaloneProducer(new NullConnection(), smtp);
   }
 

--- a/src/test/java/com/adaptris/core/mail/MailConsumerCase.java
+++ b/src/test/java/com/adaptris/core/mail/MailConsumerCase.java
@@ -16,37 +16,10 @@
 
 package com.adaptris.core.mail;
 
-import static com.adaptris.mail.JunitMailHelper.DEFAULT_RECEIVER;
-import static com.adaptris.mail.JunitMailHelper.startServer;
-import static com.adaptris.mail.JunitMailHelper.testsEnabled;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.InternetHeaders;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessageProducer;
 import com.adaptris.core.Channel;
 import com.adaptris.core.ChannelList;
-import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.Poller;
@@ -68,6 +41,34 @@ import com.adaptris.util.TimeInterval;
 import com.icegreen.greenmail.pop3.Pop3Server;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMail;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.InternetHeaders;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static com.adaptris.mail.JunitMailHelper.DEFAULT_RECEIVER;
+import static com.adaptris.mail.JunitMailHelper.startServer;
+import static com.adaptris.mail.JunitMailHelper.testsEnabled;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public abstract class MailConsumerCase extends MailConsumerExample {
 
@@ -193,8 +194,8 @@ public abstract class MailConsumerCase extends MailConsumerExample {
     consumer.setPoller(new FixedIntervalPoller(new TimeInterval(300L, TimeUnit.MILLISECONDS)));
     consumer.setReacquireLockBetweenMessages(true);
     consumer.setRegularExpressionStyle(REGEX_STYLE);
-    ConfiguredConsumeDestination dest = new ConfiguredConsumeDestination(pop3Url, "SUBJECT=.*Junit Test.*");
-    consumer.setDestination(dest);
+    consumer.setMailboxUrl(pop3Url);
+    consumer.setFilterExpression("SUBJECT=.*Junit Test.*");
     consumer.setUsername(DEFAULT_POP3_USER);
     consumer.setPassword(DEFAULT_ENCODED_POP3_PASSWORD);
     return consumer;


### PR DESCRIPTION
## Motivation

Removal of deprecated classes in interlok-core force update of optionals.

## Modification

Update/remove references to Destination objects, as they no longer exist.

## Result

The user can no longer use Destinations but has to use whatever the replacement is (here it's likely to be a String)

## Testing

The unit tests should run and pass as before and within the UI the field for Destinations should be removed and an alternative should be present.