### PR TITLE
updated use of set metadata (deprecated)

### DIFF
--- a/src/main/java/com/adaptris/core/mail/MetadataMailHeaders.java
+++ b/src/main/java/com/adaptris/core/mail/MetadataMailHeaders.java
@@ -82,7 +82,7 @@ public class MetadataMailHeaders implements MailHeaderHandler {
       Header h = (Header) headers.nextElement();
       metadata.add(new MetadataElement(pfx + h.getName(), h.getValue()));
     }
-    msg.setMetadata(filter().filter(metadata).toSet());
+    msg.addMetadata(filter().filter(metadata).toSet());
   }
 
   public String getPrefix() {


### PR DESCRIPTION
## Motivation

use of deprecated method

## Modification

updated use of setMetadata(Set<MetadataElement>) in MetadataMailHeaders.java
