### PR TITLE
Tiny change to allow the from field to support expresssions.

### DIFF
--- a/src/main/java/com/adaptris/core/mail/MailProducer.java
+++ b/src/main/java/com/adaptris/core/mail/MailProducer.java
@@ -211,7 +211,7 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
       smtp.addBlindCarbonCopy(msg.resolve(bccList));
     }
     if (getFrom() != null) {
-      smtp.setFrom(getFrom());
+      smtp.setFrom(msg.resolve(getFrom()));
     }
     MetadataCollection metadataSubset = getMetadataFilter().filter(msg);
     for (MetadataElement element : metadataSubset) {

--- a/src/main/java/com/adaptris/core/mail/MailProducer.java
+++ b/src/main/java/com/adaptris/core/mail/MailProducer.java
@@ -97,6 +97,7 @@ public abstract class MailProducer extends ProduceOnlyProducerImp {
    */
   @Getter
   @Setter
+  @InputFieldHint(expression = true)
   private String from = null;
   /**
    * A comma separated list of email addresses to 'bcc'


### PR DESCRIPTION
Interlok https://adaptris.atlassian.net/browse/INTERLOK-3923

## Motivation

So them 'from' field supports expressions in the mail producers.

## Modification

MailProducer.java

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [n/a] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [n/a] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

In the UI all mail producers that have a 'from' field now support expressions.

## Testing

Load up a copy of interlok with the latest interlok-mail.jar and in the UI check that the 'from' field supports expressions and that if you add one it resolves properly(i.e it resolves the metadata key assigned to it) If you want to test a mail is sent out you can use the following smtp server(or a locally installed one if you have it): smtp://rxdmailrelay.rbxd.ds and make sure the email arrives with the correct 'from' address.
